### PR TITLE
Change all windows paths into linux format

### DIFF
--- a/flexiznam/camp/sync_data.py
+++ b/flexiznam/camp/sync_data.py
@@ -110,7 +110,6 @@ def upload_yaml(source_yaml, raw_data_folder=None, verbose=False,
             conflicts=conflicts
         )
 
-
         # now deal with recordings' datasets
         for ds_name, ds in rec_data.get('datasets', {}).items():
             ds.mouse = mouse.name
@@ -255,10 +254,10 @@ def create_sample_datasets(parent, raw_data_folder):
     corresponding datasets
 
     Args:
-        parent (dict): Dictonary corresponding to the parent entity
+        parent (dict): Dictionary corresponding to the parent entity
 
     Return:
-        dict: dictonary of child samples
+        dict: dictionary of child samples
 
     """
     if 'samples' not in parent:
@@ -277,6 +276,7 @@ def create_sample_datasets(parent, raw_data_folder):
     # we update in place but we also return the dictionary of samples to make
     # for more readable code
     return parent['samples']
+
 
 def write_session_data_as_yaml(session_data, target_file=None, overwrite=False):
     """Write a session_data dictionary into a yaml
@@ -381,7 +381,7 @@ def clean_yaml(path_to_yaml):
         path_to_yaml (str): path to the YAML file
 
     Returns:
-        dict: nested dictonary containing entries in the YAML file
+        dict: nested dictionary containing entries in the YAML file
 
     """
     with open(path_to_yaml, 'r') as yml_file:
@@ -421,7 +421,7 @@ def read_sample(name, data):
         data,
         mandatory_args=(),
         optional_args=('notes', 'attributes', 'path'),
-        nested_levels=('datasets','samples')
+        nested_levels=('datasets', 'samples')
     )
     sample['name'] = name
 
@@ -504,8 +504,8 @@ def read_level(yml_level, mandatory_args=('project', 'mouse', 'session'),
 
     Returns:
         (tuple): a tuple containing two dictionaries:
-            level (dict): dictonary of top level attributes
-            nested_levels (dict): dictionary of nested dictonaries
+            level (dict): dictionary of top level attributes
+            nested_levels (dict): dictionary of nested dictionaries
     """
     # make a copy to not change original version
     yml_level = yml_level.copy()

--- a/flexiznam/schema/datasets.py
+++ b/flexiznam/schema/datasets.py
@@ -1,4 +1,3 @@
-import pathlib
 from pathlib import Path
 import re
 import numpy as np
@@ -8,6 +7,7 @@ from flexiznam import utils
 from flexiznam.errors import FlexilimsError, DatasetError
 from flexiznam.config import PARAMETERS
 from datetime import datetime
+
 
 class Dataset(object):
     """Master class. Should be inherited by all datasets
@@ -87,7 +87,7 @@ class Dataset(object):
             project: Name of the project or hexadecimal project_id
             name: Unique name of the dataset on flexilims
             data_series: default to None. pd.Series as returned by flz.get_entities.
-                         If provided, superseeds project and name
+                         If provided, supersedes project and name
             flm_session: authentication session to access flexilims
         """
         if data_series is not None:
@@ -330,7 +330,7 @@ class Dataset(object):
                 for field in ['path', 'created', 'is_raw', 'dataset_type']:
                     attributes[field] = fmt[field]
 
-                # reseting origin_id to null is not implemented. Specifically check
+                # resetting origin_id to null is not implemented. Specifically check
                 # that it is not attempted and crash if it is
                 if self.origin_id is None:
                     if self.get_flexilims_entry().get('origin_id', None) is not None:

--- a/flexiznam/utils.py
+++ b/flexiznam/utils.py
@@ -1,5 +1,5 @@
 import pathlib
-from pathlib import Path,PurePosixPath
+from pathlib import Path, PurePosixPath
 
 import pandas as pd
 


### PR DESCRIPTION
Convert dataset path to PurePosixPath first before converting to string in `clean_dictionary_recursively` in `utils.py`. This will change all windows paths into linux paths when generating the full yaml file and upload the linux paths onto flexilims. 
Please see example from Project `hey2_3d-vision_20210716` Session `S20210915` (which was uploaded from a windows desktop). 